### PR TITLE
Force https instead of SSH in docker recursive clones

### DIFF
--- a/docker/Dockerfile-petibm0.4.2-xenial
+++ b/docker/Dockerfile-petibm0.4.2-xenial
@@ -9,6 +9,10 @@ RUN apt-get update && \
         build-essential cmake bzip2 git && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Force git to use https instead of ssh. This prevents an error when recursively cloning into rescience-rollingpitching
+RUN git config --global url."https://github.com/".insteadOf git@github.com: && \
+	git config --global url."https://".insteadOf git://
+
 # Install PetIBM app `petibm-rollingpitching`.
 ADD https://api.github.com/repos/mesnardo/petibm-rollingpitching/git/refs/heads/master version.json
 RUN URL=https://github.com/mesnardo/petibm-rollingpitching.git && \

--- a/docker/Dockerfile-petibm0.5-xenial
+++ b/docker/Dockerfile-petibm0.5-xenial
@@ -9,6 +9,10 @@ RUN apt-get update && \
         build-essential cmake bzip2 git && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Force git to use https instead of ssh. This prevents an error when recursively cloning into rescience-rollingpitching
+RUN git config --global url."https://github.com/".insteadOf git@github.com: && \
+	git config --global url."https://".insteadOf git://
+
 # Install PetIBM app `petibm-rollingpitching`.
 ADD https://api.github.com/repos/mesnardo/petibm-rollingpitching/git/refs/heads/master version.json
 RUN URL=https://github.com/mesnardo/petibm-rollingpitching.git && \

--- a/docker/Dockerfile-petibm0.5.1-xenial
+++ b/docker/Dockerfile-petibm0.5.1-xenial
@@ -9,6 +9,10 @@ RUN apt-get update && \
         build-essential cmake bzip2 git && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Force git to use https instead of ssh. This prevents an error when recursively cloning into rescience-rollingpitching
+RUN git config --global url."https://github.com/".insteadOf git@github.com: && \
+	git config --global url."https://".insteadOf git://
+
 # Install PetIBM app `petibm-rollingpitching`.
 ADD https://api.github.com/repos/mesnardo/petibm-rollingpitching/git/refs/heads/master version.json
 RUN URL=https://github.com/mesnardo/petibm-rollingpitching.git && \


### PR DESCRIPTION
The current docker files all fail to build with similar error messages:

```
Step 5/11 : RUN URL=https://github.com/mesnardo/petibm-rollingpitching.git &&     PETIBMAPP_DIR=/opt/petibm-rollingpitching &&     git clone --recursive ${URL} ${PETIBMAPP_DIR} &&     BUILDDIR=${PETIBMAPP_DIR}/build &&     mkdir -p ${BUILDDIR} &&     cd ${BUILDDIR} &&     cmake ${PETIBMAPP_DIR}         -DCMAKE_INSTALL_PREFIX=/usr/local/petibm-apps         -DCMAKE_C_COMPILER=mpicc         -DCMAKE_CXX_COMPILER=mpicxx         -DPETIBM_DIR=${PETIBM_DIR}         -DPETSC_DIR=${PETSC_DIR}         -DPETSC_ARCH=""         -DYAMLCPP_DIR=${PETIBM_DIR}         -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON         -DCMAKE_BUILD_TYPE=RELEASE &&     make all &&     make install
 ---> Running in 2000c5132ddf
Cloning into '/opt/petibm-rollingpitching'...
Submodule 'cmake-modules' (https://github.com/jedbrown/cmake-modules.git) registered for path 'cmake-modules'
Submodule 'rescience-rollingpitching' (git@github.com:barbagroup/rescience-rollingpitching.git) registered for path 'rescience-rollingpitching'
Cloning into 'cmake-modules'...
Submodule path 'cmake-modules': checked out '91f96174a8b3f65e19519fa592b1571391c0e3d0'
Cloning into 'rescience-rollingpitching'...
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:barbagroup/rescience-rollingpitching.git' into submodule path 'rescience-rollingpitching' failed
```

I believe this is some sort of error with regards to repository ssh keys but I'm not really sure. I have fixed the problem by forcing git to use the https endpoints instead of cloning over ssh. With these changes all the dockerfiles build successfully:

```
Step 4/12 : RUN git config --global url."https://github.com/".insteadOf git@github.com: && 	git config --global url."https://".insteadOf git://
 ---> Running in 78c1647e13c4
Removing intermediate container 78c1647e13c4
 ---> 9cefa52df796
Step 5/12 : ADD https://api.github.com/repos/mesnardo/petibm-rollingpitching/git/refs/heads/master version.json
Downloading     377B
 ---> 7df4d62a4770
Step 6/12 : RUN URL=https://github.com/mesnardo/petibm-rollingpitching.git &&     PETIBMAPP_DIR=/opt/petibm-rollingpitching &&     git clone --recursive ${URL} ${PETIBMAPP_DIR} &&     BUILDDIR=${PETIBMAPP_DIR}/build &&     mkdir -p ${BUILDDIR} &&     cd ${BUILDDIR} &&     cmake ${PETIBMAPP_DIR}         -DCMAKE_INSTALL_PREFIX=/usr/local/petibm-apps         -DCMAKE_C_COMPILER=mpicc         -DCMAKE_CXX_COMPILER=mpicxx         -DPETIBM_DIR=${PETIBM_DIR}         -DPETSC_DIR=${PETSC_DIR}         -DPETSC_ARCH=""         -DYAMLCPP_DIR=${PETIBM_DIR}         -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON         -DCMAKE_BUILD_TYPE=RELEASE &&     make all &&     make install
 ---> Running in 21c681d8018f
Cloning into '/opt/petibm-rollingpitching'...
Submodule 'cmake-modules' (https://github.com/jedbrown/cmake-modules.git) registered for path 'cmake-modules'
Submodule 'rescience-rollingpitching' (git@github.com:barbagroup/rescience-rollingpitching.git) registered for path 'rescience-rollingpitching'
Cloning into 'cmake-modules'...
Submodule path 'cmake-modules': checked out '91f96174a8b3f65e19519fa592b1571391c0e3d0'
Cloning into 'rescience-rollingpitching'...
Submodule path 'rescience-rollingpitching': checked out '7ca64284517a40996936fb87816b33d0c634c461'
-- The C compiler identification is GNU 5.4.0
-- The CXX compiler identification is GNU 5.4.0
-- Check for working C compiler: /usr/local/openmpi-3.1.4/bin/mpicc
-- Check for working C compiler: /usr/local/openmpi-3.1.4/bin/mpicc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/local/openmpi-3.1.4/bin/mpicxx
-- Check for working CXX compiler: /usr/local/openmpi-3.1.4/bin/mpicxx -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
```