### PR TITLE
Use https endpoint for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/jedbrown/cmake-modules.git
 [submodule "rescience-rollingpitching"]
 	path = rescience-rollingpitching
-	url = git@github.com:barbagroup/rescience-rollingpitching.git
+	url = https://github.com/barbagroup/rescience-rollingpitching.git


### PR DESCRIPTION
`docker build` will currently fail after the new `rescience-rollingpitching` submodule was added.

Issue was reported by @VanillaBrooks (thank you!), who suggested to configure git to use `https` endpoint within each of the Dockerfiles.

A similar approach (this PR) is to update `.gitmodules` to use the `https` endpoint for the`rescience-rollingpitching` submodule (so that we don't have to modify all the Dockerfiles).