### PR TITLE
ReScience revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ See [this README section](runs/README.md/#hardware-configuration-and-run-times).
 
 * Olivier Mesnard & Lorena A. Barba (2021). [Re] Three-dimensional wake topology and propulsive performance of low-aspect-ratio pitching-rolling plates (repro-packs). [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4732946.svg)](https://doi.org/10.5281/zenodo.4732946)
 
-Download the Zenodo archive (20G) with the primary data output from PetIBM.
+Download the Zenodo archive (18.6 GB) with the primary data output from PetIBM.
+
+| :warning: WARNING |
+|:-|
+| Generating secondary data (e.g., 3D vorticity field) requires a machine with more than 16 GB of memory (32 GB is recommended). If you do not have access to such machine, one solution is to launch a `t3.2xlarge` EC2 instance on AWS and run the Docker container there (see [instructions](misc/repro-packs-on-aws.md)). |
 
 Generate all secondary data and figures of the manuscript (~20 minutes):
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ The deposit (4.7GB) contains the Docker and Singularity images used for the repl
 
 We used Docker 1.39 (see [version info](docker/Docker.version)) and Singularity 3.4.2.
 
+## Software/Hardware requirements
+
+The following list of libraries and tools should be installed on the host machine to be able to run the Singularity image:
+
+* CUDA Toolkit 10.1
+* Singularity 3.4+
+* OpenMPI 3.1.4
+
+The NVIDIA AmgX library contained in the Docker image `mesnardo/petibm-rollingpitching:PetIBM0.5.1-xenial` was compiled with CUDA Toolkit 10.1 to target NVIDIA GPUs with a compute capability of 3.5 (Kepler - Tesla K20, K40), 3.7 (Kepler - Tesla K80), 6.0 (Pascal - Tesla P100), and 7.0 (Volta - Tesla V100).
+
+Note we used NVIDIA V100 GPUs to solve the pressure Poisson system in our simulations; the two other linear systems were solved on CPUs with the PETSc library.
+If no GPUs are available on the host machine, one should still be able to use the same Docker or Singularity image and solve the Poisson system on CPUs.
+Otherwise, one should be able to launch and configure an AWS EC2 instance following [these instructions](misc/running-on-aws.md).
+
 ## Hardware configuration and run times
 
 See [this README section](runs/README.md/#hardware-configuration-and-run-times).

--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ This repository contains a computational replication of the scientific findings 
 * [PetibmPy](https://github.com/mesnardo/petibmpy) (0.2)
 * [VisIt](https://wci.llnl.gov/simulation/computer-codes/visit) (2.12.3)
 
+## Container images
+
+* Olivier Mesnard & Lorena A. Barba (2021). [Re] Three-dimensional wake topology and propulsive performance of low-aspect-ratio pitching-rolling plates (container images). [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5090342.svg)](https://doi.org/10.5281/zenodo.5090342)
+
+The deposit (4.7GB) contains the Docker and Singularity images used for the replication:
+
+* `petibm-rollingpitching_PetIBM0.5.1-xenial.tar`: tar archive of the Docker image `mesnardo/petibm-rollingpitching:PetIBM0.5.1-xenial` which includes the PetIBM application for the 3D rolling and pitching wing
+* `petibm-rollingpitching_PetIBM0.5.1-xenial.sif`: Singularity image (build from the Docker image) that was used to run the simulations on the `pegasus` HPC cluster (at the George Washington University)
+* `petibm-rollingpitching_prepost.tar`: tar archive of the Docker image `mesnardo/petibm-rollingpitching:prepost` which contains all tools to pre- and post-process the numerical outputs of the simulations
+
 ## Reproducibility packages
 
 * Olivier Mesnard & Lorena A. Barba (2021). [Re] Three-dimensional wake topology and propulsive performance of low-aspect-ratio pitching-rolling plates (repro-packs). [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4732946.svg)](https://doi.org/10.5281/zenodo.4732946)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ The deposit (4.7GB) contains the Docker and Singularity images used for the repl
 * `petibm-rollingpitching_PetIBM0.5.1-xenial.sif`: Singularity image (build from the Docker image) that was used to run the simulations on the `pegasus` HPC cluster (at the George Washington University)
 * `petibm-rollingpitching_prepost.tar`: tar archive of the Docker image `mesnardo/petibm-rollingpitching:prepost` which contains all tools to pre- and post-process the numerical outputs of the simulations
 
+## Hardware configuration and run times
+
+See [this README section](runs/README.md/#hardware-configuration-and-run-times).
+
 ## Reproducibility packages
 
 * Olivier Mesnard & Lorena A. Barba (2021). [Re] Three-dimensional wake topology and propulsive performance of low-aspect-ratio pitching-rolling plates (repro-packs). [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4732946.svg)](https://doi.org/10.5281/zenodo.4732946)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The deposit (4.7GB) contains the Docker and Singularity images used for the repl
 * `petibm-rollingpitching_PetIBM0.5.1-xenial.sif`: Singularity image (build from the Docker image) that was used to run the simulations on the `pegasus` HPC cluster (at the George Washington University)
 * `petibm-rollingpitching_prepost.tar`: tar archive of the Docker image `mesnardo/petibm-rollingpitching:prepost` which contains all tools to pre- and post-process the numerical outputs of the simulations
 
+We used Docker 1.39 (see [version info](docker/Docker.version)) and Singularity 3.4.2.
+
 ## Hardware configuration and run times
 
 See [this README section](runs/README.md/#hardware-configuration-and-run-times).

--- a/docker/Docker.version
+++ b/docker/Docker.version
@@ -1,0 +1,19 @@
+# docker version on phantom
+Client: Docker Engine - Community
+ Version:           19.03.10
+ API version:       1.39
+ Go version:        go1.13.10
+ Git commit:        9424aeaee9
+ Built:             Thu May 28 22:17:05 2020
+ OS/Arch:           linux/amd64
+ Experimental:      false
+
+Server: Docker Engine - Community
+ Engine:
+  Version:          18.09.7
+  API version:      1.39 (minimum version 1.12)
+  Go version:       go1.10.8
+  Git commit:       2d0083d
+  Built:            Thu Jun 27 17:23:02 2019
+  OS/Arch:          linux/amd64
+  Experimental:     false

--- a/misc/repro-packs-on-aws.md
+++ b/misc/repro-packs-on-aws.md
@@ -1,0 +1,63 @@
+# Repro-Packs on AWS
+
+1. Sign-in to your AWS account
+2. Go to EC2, switch to your preferred Region, and click "Launch instance"
+3. Choose one of the Ubuntu AMIs (e.g., "Ubuntu Server 20.04 LTS (HVM), SSD Volume Type")
+4. Choose the `t3.2xlarge` instance type (or a similar one with 32 GB of memory)
+5. Use a Bootstrap script to install and start Docker on the instance:
+
+   ```bash
+   #!/bin/bash
+   sudo snap install docker
+   sudo addgroup --system docker
+   sudo adduser ubuntu docker
+   newgrp docker
+   sudo snap disable docker
+   sudo snap enable docker
+   ```
+
+6. Request 60 GB for the Root volume (gp2 volume type is fine)
+7. Use a Security Group with SSH to your IP address
+8. Review, set your Permission Key-Pair, and Launch
+9. Once the instance is provisioned, connect to it
+
+   ```shell
+   ssh -i <pem-path> ubuntu@<public-ipv4-dns-or-address>
+   ```
+
+10. Install `unzip`
+
+    ```shell
+    sudo apt install unzip
+    ```
+
+11. Download the repro-packs from Zenodo and unzip the archive
+
+    ```shell
+    ARCHIVE=petibm-rollingpitching_repro-packs.zip
+    curl --output $ARCHIVE https://zenodo.org/record/4732946/files/$ARCHIVE
+    unzip $ARCHIVE
+    rm -f $ARCHIVE
+    ```
+
+12. Download the container images from Zenodo and unzip the archive
+
+    ```shell
+    ARCHIVE=petibm-rollingpitching-images.zip
+    curl --output $ARCHIVE https://zenodo.org/record/5090342/files/$ARCHIVE
+    unzip $ARCHIVE
+    rm -f $ARCHIVE
+    ```
+
+13. Load the Docker image for post-processing the data
+
+    ```shell
+    docker load -i petibm-rollingpitching-images/petibm-rollingpitching_prepost.tar
+    ```
+
+14. Run a Docker container to generate the secondary data and figures
+
+    ```shell
+    cd repro-packs
+    docker run --rm -it -v $(pwd):/postprocessing mesnardo/petibm-rollingpitching:prepost /bin/bash /postprocessing/scripts/generate_all_figures.sh > repro-packs.log 2>&1
+    ```

--- a/misc/running-on-aws.md
+++ b/misc/running-on-aws.md
@@ -1,0 +1,109 @@
+# Running simulations on AWS
+
+1. Sign-in to your AWS account
+2. Go to EC2, switch to your preferred Region, and click "Launch instance"
+3. Choose one the Ubuntu 18.04 AMI
+4. Choose the `p2.8xlarge` instance type (8 NVIDIA K80 GPUs, 32 vCPUs, 488 GiB Mem, 96 GiB GPU Mem). (`p2.xlarge` does not have enough memory for the base case simulation.)
+5. Use a Bootstrap script to install and start Docker on the instance:
+
+   ```bash
+   #!/bin/bash
+   sudo snap install docker
+   sudo addgroup --system docker
+   sudo adduser ubuntu docker
+   newgrp docker
+   sudo snap disable docker
+   sudo snap enable docker
+   ```
+
+6. Request 100 GB for the Root volume (gp2 volume type is fine)
+7. Use a Security Group with SSH to your IP address
+8. Review, set your Permission Key-Pair, and Launch
+9. Once the instance is provisioned, connect to it
+
+   ```shell
+   ssh -i <pem-path> ubuntu@<public-ipv4-dns-or-address>
+   ```
+
+10. On the EC2 instance, install dependencies for Singularity
+
+    ```shell
+    sudo apt update
+    sudo apt install -y build-essential libssl-dev uuid-dev libgpgme11-dev libseccomp-dev wget pkg-config git
+    ```
+
+11. Install CUDA Toolkit 10.1
+
+    ```shell
+    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin
+    sudo mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600
+    sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
+    sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
+    sudo apt update
+    sudo apt -y install cuda-10-1
+    ```
+
+12. Install GO (required for Singularity)
+
+    ```shell
+    export VERSION=1.14.12 OS=linux ARCH=amd64
+    wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz
+    sudo tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz
+    rm -f go$VERSION.$OS-$ARCH.tar.gz
+    export PATH=/usr/local/go/bin:$PATH
+    ```
+
+13. Install Singularity
+
+    ```shell
+    export VERSION=3.8.0
+    wget https://github.com/hpcng/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz
+    tar -xzf singularity-${VERSION}.tar.gz
+    rm -f singularity-${VERSION}.tar.gz
+    cd singularity-${VERSION}
+    ./mconfig -V ${VERSION}
+    make -C builddir
+    sudo make -C builddir install
+    ```
+
+14. Install nvidia-container-cli
+
+    ```shell
+    DIST=$(. /etc/os-release; echo $ID$VERSION_ID)
+    curl -s -L https://nvidia.github.io/libnvidia-container/gpgkey | sudo apt-key add -
+    curl -s -L https://nvidia.github.io/libnvidia-container/${DIST}/libnvidia-container.list | sudo tee /etc/apt/sources.list.d/libnvidia-container.list
+    sudo apt update
+    sudo apt install libnvidia-container-tools
+    ```
+
+15. Download the Zenodo archive with container images
+
+    ```shell
+    ARCHIVE=petibm-rollingpitching-images.zip
+    curl --output $ARCHIVE https://zenodo.org/record/5090342/files/$ARCHIVE
+    unzip $ARCHIVE
+    rm -f $ARCHIVE
+    ```
+
+16. Load the pre-processing Docker image
+
+    ```shell
+    docker load -i petibm-rollingpitching-images/petibm-rollingpitching_prepost.tar
+    ```
+
+17. Download the Zenodo archive with the application input data
+
+    ```shell
+    ARCHIVE=petibm-rollingpitching-2021.05.02.zip
+    curl --output $ARCHIVE https://zenodo.org/record/4733323/files/$ARCHIVE
+    unzip $ARCHIVE
+    rm -f $ARCHIVE
+    ```
+
+18. Run the base case simulation
+
+    ```shell
+    cd petibm-rollingpitching-2021.05.02/runs/Re200_St0.6_AR1.27_psi90
+    docker run --rm -v $(pwd):/volume mesnardo/petibm-rollingpitching:prepost python /volume/scripts/create_body.py
+    SINGULARITY_CUDA_VISIBLE_DEVICES=0,1,2,3 singularity exec --nv ~/petibm-rollingpitching-images/petibm-rollingpitching_petibm0.5.1-xenial.sif mpirun --use-hwthread-cpus petibm-rollingpitching -probes probes.yaml -options_left -log_view ascii:view.log
+    ```

--- a/runs/README.md
+++ b/runs/README.md
@@ -10,43 +10,46 @@ The present directory contains all the input files and post-processing scripts, 
 * `Re*_St*_AR*_psi*`: simulation folders of the parametric study; for example:
   * `Re200_St0.6_AR1.27_psi90`: simulation folder to compute the three-dimensional flow around a pitching and rolling flat plate with aspect ratio `AR=1.27` at Reynolds number `Re=200`, Strouhal number `St=0.6`, with a phase difference of `psi=90` degrees between the rolling and pitching motions.
 
-## Runtimes
+## Hardware configuration and run times
 
-Each simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), using nodes of the `small-gpu` partition.
+Each simulation job was submitted to the SLURM scheduling system on Pegasus (HPC cluster at the George Washington University), using nodes of the `small-gpu` partition.
 
-Hardware configuration of small GPU nodes:
+Hardware configuration of the nodes on the `small-gpu` partition:
 
 * Dell PowerEdge R740 server
-* (2) NVIDIA Tesla V100 GPU
+* (2) NVIDIA Tesla V100 GPU (Memory size: 16GB)
 * Dual 20-Core 3.70GHz Intel Xeon Gold 6148 processors
 * 192GB of 2666MHz DDR4 ECC Register DRAM
 * 800 GB SSD onboard storage (used for boot and local scratch space)
 * Mellanox EDR Infiniband controller to 100GB fabric
 
+For each simulation, we used 20 CPUs and 2 GPU devices per node.
+Information about the number of nodes, the number of time steps computed, the mesh size, and the run time for each simulation are displayed in the following table.
+
 | Simulation | # time steps | # grid cells (10^6) | # nodes | runtime (hr) |
 |:-|:-:|:-:|:-:|:-:|
-| `independence/run1` | 10000 | 5.1 | 1 | 3.0 |
-| `independence/run2` | 10000 | 11.5 | 1 | 7.4 |
-| `independence/run3` | 10000 | 21.1 | 2 | 8.4 |
-| `independence/run4` | 10000 | 72.3 | 6 | 23.7 |
-| `independence/run5` | 10000 | 21.1 | 2 | 10.8 |
-| `independence/run6` | 5000 | 21.1 | 2 | 5.1 |
-| `independence/run7` | 10000 | 21.1 | 2 | 12.8 |
-| `Re100_St0.6_AR1.27_psi90` | 10000 | 21.1 | 2 | 11.0 |
-| `Re200_St0.4_AR1.27_psi90` | 10000 | 21.1 | 2 | 9.8 |
-| `Re200_St0.6_AR1.27_psi100` | 10000 | 21.1 | 2 | 9.1 |
-| `Re200_St0.6_AR1.27_psi110` | 10000 | 21.1 | 2 | 8.1 |
-| `Re200_St0.6_AR1.27_psi120` | 10000 | 21.1 | 2 | 9.0 |
-| `Re200_St0.6_AR1.27_psi60` | 10000 | 21.1 | 2 | 8.1 |
-| `Re200_St0.6_AR1.27_psi70` | 10000 | 21.1 | 2 | 9.7 |
-| `Re200_St0.6_AR1.27_psi80` | 10000 | 21.1 | 2 | 9.7 |
-| `Re200_St0.6_AR1.27_psi90` | 10000 | 21.1 | 2 | 13.8 |
-| `Re200_St0.6_AR1.91_psi90` | 10000 | 29.9 | 2 | 9.0 |
-| `Re200_St0.6_AR2.55_psi90` | 10000 | 42.6 | 2 | 12.8 |
-| `Re200_St0.8_AR1.27_psi90` | 10000 | 21.1 | 2 | 9.2 |
-| `Re200_St1.0_AR1.27_psi90` | 10000 | 21.1 | 2 | 8.2 |
-| `Re200_St1.2_AR1.27_psi90` | 10000 | 21.1 | 2 | 12.2 |
-| `Re400_St0.6_AR1.27_psi90` | 10000 | 21.1 | 2 | 11.0 |
+| `independence/run1` | 10,000 | 5.1 | 1 | 3.0 |
+| `independence/run2` | 10,000 | 11.5 | 1 | 7.4 |
+| `independence/run3` | 10,000 | 21.1 | 2 | 8.4 |
+| `independence/run4` | 10,000 | 72.3 | 6 | 23.7 |
+| `independence/run5` | 10,000 | 21.1 | 2 | 10.8 |
+| `independence/run6` | 5,000 | 21.1 | 2 | 5.1 |
+| `independence/run7` | 10,000 | 21.1 | 2 | 12.8 |
+| `Re100_St0.6_AR1.27_psi90` | 10,000 | 21.1 | 2 | 11.0 |
+| `Re200_St0.4_AR1.27_psi90` | 10,000 | 21.1 | 2 | 9.8 |
+| `Re200_St0.6_AR1.27_psi100` | 10,000 | 21.1 | 2 | 9.1 |
+| `Re200_St0.6_AR1.27_psi110` | 10,000 | 21.1 | 2 | 8.1 |
+| `Re200_St0.6_AR1.27_psi120` | 10,000 | 21.1 | 2 | 9.0 |
+| `Re200_St0.6_AR1.27_psi60` | 10,000 | 21.1 | 2 | 8.1 |
+| `Re200_St0.6_AR1.27_psi70` | 10,000 | 21.1 | 2 | 9.7 |
+| `Re200_St0.6_AR1.27_psi80` | 10,000 | 21.1 | 2 | 9.7 |
+| `Re200_St0.6_AR1.27_psi90` | 10,000 | 21.1 | 2 | 13.8 |
+| `Re200_St0.6_AR1.91_psi90` | 10,000 | 29.9 | 4 | 9.0 |
+| `Re200_St0.6_AR2.55_psi90` | 10,000 | 42.6 | 4 | 12.8 |
+| `Re200_St0.8_AR1.27_psi90` | 10,000 | 21.1 | 2 | 9.2 |
+| `Re200_St1.0_AR1.27_psi90` | 10,000 | 21.1 | 2 | 8.2 |
+| `Re200_St1.2_AR1.27_psi90` | 10,000 | 21.1 | 2 | 12.2 |
+| `Re400_St0.6_AR1.27_psi90` | 10,000 | 21.1 | 2 | 11.0 |
 
 ## Post-processing steps
 

--- a/runs/README.md
+++ b/runs/README.md
@@ -13,6 +13,7 @@ The present directory contains all the input files and post-processing scripts, 
 ## Hardware configuration and run times
 
 Each simulation job was submitted to the SLURM scheduling system on Pegasus (HPC cluster at the George Washington University), using nodes of the `small-gpu` partition.
+(Note: The SLURM submission scripts were designed for the user `mesnardo` to run on Pegasus; do not use them as such; use them as an example to develop your own submission script.)
 
 Hardware configuration of the nodes on the `small-gpu` partition:
 

--- a/runs/Re100_St0.6_AR1.27_psi90/README.md
+++ b/runs/Re100_St0.6_AR1.27_psi90/README.md
@@ -36,6 +36,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 2 nodes of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 

--- a/runs/Re200_St0.4_AR1.27_psi90/README.md
+++ b/runs/Re200_St0.4_AR1.27_psi90/README.md
@@ -36,6 +36,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 2 nodes of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 

--- a/runs/Re200_St0.6_AR1.27_psi100/README.md
+++ b/runs/Re200_St0.6_AR1.27_psi100/README.md
@@ -36,6 +36,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 2 nodes of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 

--- a/runs/Re200_St0.6_AR1.27_psi110/README.md
+++ b/runs/Re200_St0.6_AR1.27_psi110/README.md
@@ -36,6 +36,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 2 nodes of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 

--- a/runs/Re200_St0.6_AR1.27_psi120/README.md
+++ b/runs/Re200_St0.6_AR1.27_psi120/README.md
@@ -36,6 +36,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 2 nodes of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 

--- a/runs/Re200_St0.6_AR1.27_psi60/README.md
+++ b/runs/Re200_St0.6_AR1.27_psi60/README.md
@@ -36,6 +36,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 2 nodes of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 

--- a/runs/Re200_St0.6_AR1.27_psi70/README.md
+++ b/runs/Re200_St0.6_AR1.27_psi70/README.md
@@ -36,6 +36,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 2 nodes of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 

--- a/runs/Re200_St0.6_AR1.27_psi80/README.md
+++ b/runs/Re200_St0.6_AR1.27_psi80/README.md
@@ -36,6 +36,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 2 nodes of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 

--- a/runs/Re200_St0.6_AR1.27_psi90/README.md
+++ b/runs/Re200_St0.6_AR1.27_psi90/README.md
@@ -36,6 +36,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 2 nodes of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 

--- a/runs/Re200_St0.6_AR1.27_psi90/figures/meshgrid.png
+++ b/runs/Re200_St0.6_AR1.27_psi90/figures/meshgrid.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e9437a01e1d0858a8ca1482b6b0567bcf701e9edf70fd0a59e96d3a33532f5f
+size 2538142

--- a/runs/Re200_St0.6_AR1.27_psi90/pegasus.slurm
+++ b/runs/Re200_St0.6_AR1.27_psi90/pegasus.slurm
@@ -39,7 +39,7 @@ echo $SLURM_JOB_ID
 printf "\n*** JOB NODE LIST ***\n"
 echo $SLURM_JOB_NODELIST
 
-simudir="/lustre/groups/barbalab/mesnardo/rollingpitching/Re200_St0.6_AR1.27_psi90-new"
+simudir="/lustre/groups/barbalab/mesnardo/rollingpitching/Re200_St0.6_AR1.27_psi90"
 indir="/mnt"
 img="/SEAS/home/mesnardo/images/petibm-rollingpitching_petibm0.5.1-xenial.sif"
 

--- a/runs/Re200_St0.6_AR1.27_psi90/scripts/plot_meshgrid.py
+++ b/runs/Re200_St0.6_AR1.27_psi90/scripts/plot_meshgrid.py
@@ -1,0 +1,119 @@
+"""Plot the mesh grid."""
+
+import itertools
+import pathlib
+
+import numpy
+from matplotlib import pyplot
+from mpl_toolkits.mplot3d import Axes3D
+from scipy.spatial import ConvexHull
+
+import petibmpy
+import rodney
+
+
+def subset_gridline(x, xs, xe):
+    """Return subset of gridline points given a target start and end."""
+    mask, = numpy.where((x >= xs) & (x <= xe))
+    x = x[mask]
+    xlim = (min(x), max(x))
+    return x, xlim
+
+
+args = rodney.parse_command_line()
+maindir = pathlib.Path(__file__).parents[1]
+datadir = maindir / 'output'
+
+# Load gridline coordinates from file.
+filepath = datadir / 'grid.h5'
+x, y, z = petibmpy.read_grid_hdf5(filepath, 'vertex')
+
+# Subset gridline coordinates.
+x, xlim = subset_gridline(x, -5.0, 5.0)
+y, ylim = subset_gridline(y, -5.0, 5.0)
+z, zlim = subset_gridline(z, -5.0, 5.0)
+
+# Load body coordinates from file.
+filepath = maindir / 'wing.body'
+wing = rodney.WingKinematics()
+wing.load_body(filepath, skiprows=1)
+
+# Keep only points on the contour of the wing.
+x0, _, z0 = wing.get_coordinates(org=True)
+points = numpy.array([x0, z0]).T
+hull = ConvexHull(points)
+x0, z0 = points[hull.vertices, 0], points[hull.vertices, 1]
+y0 = numpy.zeros_like(x0)
+wing.set_coordinates(x0, y0, z0, org=True)
+
+# Get position at given time.
+xb, yb, zb = wing.compute_position(0.0)
+
+pyplot.rc('font', family='serif', size=12)
+
+fig = pyplot.figure(figsize=(6.0, 6.0))
+ax = Axes3D(fig, proj_type='persp')
+
+ax.grid(False)
+ax.xaxis.pane.fill = False
+ax.yaxis.pane.fill = False
+ax.zaxis.pane.fill = False
+ax.xaxis.pane.set_edgecolor('w')
+ax.yaxis.pane.set_edgecolor('w')
+ax.zaxis.pane.set_edgecolor('w')
+
+ax.set_xlabel('x / c', labelpad=-10.0)
+ax.set_ylabel('z / c', labelpad=-10.0)
+ax.set_zlabel('y / c', labelpad=-10.0)
+
+# Draw surrounding box.
+lx, ly, lz = xlim[1] - xlim[0], ylim[1] - ylim[0], zlim[1] - zlim[0]
+points = numpy.array(list(itertools.product(xlim, zlim, ylim)))
+for s, e in itertools.combinations(points, 2):
+    v = numpy.sum(numpy.abs(s - e))
+    if v == lx or v == ly or v == lz:
+        ax.plot3D(*zip(s, e), color='black', linestyle=':')
+
+# Plot x/y gridlines at z_min.
+X, Y = numpy.meshgrid(x, y)
+Z = numpy.array([[min(z)]])
+ax.plot_wireframe(X, Z, Y,
+                  rstride=1, cstride=1, linewidth=0.1, color='black')
+
+# Plot y/z gridlines at x_min.
+Y, Z = numpy.meshgrid(y, z)
+X = numpy.array([[min(x)]])
+ax.plot_wireframe(X, Z, Y,
+                  rstride=1, cstride=1, linewidth=0.1, color='black')
+
+# Plot x/z gridlines at y_min
+Z, X = numpy.meshgrid(z, x)
+Y = numpy.array([[min(y)]])
+ax.plot_wireframe(X, Z, Y,
+                  rstride=1, cstride=1, linewidth=0.1, color='black')
+
+# Plot wing.
+ax.plot_trisurf(xb, zb, yb, color='C0')
+# Add hinge.
+ax.scatter(0.0, 0.0, 0.0, depthshade=False, c='black', marker='x', s=50)
+
+ax.set_xlim3d(xlim)
+ax.set_ylim3d(zlim[::-1])
+ax.set_zlim3d(ylim)
+
+ticks = numpy.arange(-5.0, 5.1, 2.5)
+ax.set_xticks(ticks)
+ax.set_xticklabels([None] * ticks.size)
+ax.set_yticks(ticks)
+ax.set_yticklabels([None] * ticks.size)
+ax.set_zticks(ticks)
+ax.set_zticklabels([None] * ticks.size)
+
+if args.save_figures:
+    figdir = maindir / 'figures'
+    figdir.mkdir(parents=True, exist_ok=True)
+    filepath = figdir / 'meshgrid.png'
+    fig.savefig(filepath, dpi=300, bbox_inches='tight')
+
+if args.show_figures:
+    pyplot.show()

--- a/runs/Re200_St0.6_AR1.91_psi90/README.md
+++ b/runs/Re200_St0.6_AR1.91_psi90/README.md
@@ -36,6 +36,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 2 nodes of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 

--- a/runs/Re200_St0.6_AR1.91_psi90/README.md
+++ b/runs/Re200_St0.6_AR1.91_psi90/README.md
@@ -46,7 +46,7 @@ Hardware configuration of small GPU nodes:
 * 800 GB SSD onboard storage (used for boot and local scratch space)
 * Mellanox EDR Infiniband controller to 100GB fabric
 
-The simulation computed 10000 time steps in about 9 hours on 2 `small-gpu` nodes (20 MPI processes and 2 GPU devices per node) in a Singularity container.
+The simulation computed 10000 time steps in about 9 hours on 4 `small-gpu` nodes (20 MPI processes and 2 GPU devices per node) in a Singularity container.
 
 ## Post-processing steps
 

--- a/runs/Re200_St0.6_AR2.55_psi90/README.md
+++ b/runs/Re200_St0.6_AR2.55_psi90/README.md
@@ -36,6 +36,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 2 nodes of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 

--- a/runs/Re200_St0.6_AR2.55_psi90/README.md
+++ b/runs/Re200_St0.6_AR2.55_psi90/README.md
@@ -46,7 +46,7 @@ Hardware configuration of small GPU nodes:
 * 800 GB SSD onboard storage (used for boot and local scratch space)
 * Mellanox EDR Infiniband controller to 100GB fabric
 
-The simulation computed 10000 time steps in about 12.8 hours on 2 `small-gpu` nodes (20 MPI processes and 2 GPU devices per node) in a Singularity container.
+The simulation computed 10000 time steps in about 12.8 hours on 4 `small-gpu` nodes (20 MPI processes and 2 GPU devices per node) in a Singularity container.
 
 ## Post-processing steps
 

--- a/runs/Re200_St0.8_AR1.27_psi90/README.md
+++ b/runs/Re200_St0.8_AR1.27_psi90/README.md
@@ -36,6 +36,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 2 nodes of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 

--- a/runs/Re200_St1.0_AR1.27_psi90/README.md
+++ b/runs/Re200_St1.0_AR1.27_psi90/README.md
@@ -36,6 +36,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 2 nodes of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 

--- a/runs/Re200_St1.2_AR1.27_psi90/README.md
+++ b/runs/Re200_St1.2_AR1.27_psi90/README.md
@@ -36,6 +36,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 2 nodes of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 

--- a/runs/Re400_St0.6_AR1.27_psi90/README.md
+++ b/runs/Re400_St0.6_AR1.27_psi90/README.md
@@ -36,6 +36,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 2 nodes of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 

--- a/runs/independence/run1/README.md
+++ b/runs/independence/run1/README.md
@@ -35,6 +35,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 1 node of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 

--- a/runs/independence/run2/README.md
+++ b/runs/independence/run2/README.md
@@ -35,6 +35,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 1 node of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 

--- a/runs/independence/run3/README.md
+++ b/runs/independence/run3/README.md
@@ -35,6 +35,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 2 nodes of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 

--- a/runs/independence/run4/README.md
+++ b/runs/independence/run4/README.md
@@ -35,6 +35,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 6 nodes of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 

--- a/runs/independence/run5/README.md
+++ b/runs/independence/run5/README.md
@@ -35,6 +35,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 2 nodes of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 

--- a/runs/independence/run6/README.md
+++ b/runs/independence/run6/README.md
@@ -35,6 +35,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 2 nodes of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 

--- a/runs/independence/run7/README.md
+++ b/runs/independence/run7/README.md
@@ -35,6 +35,7 @@ and run the instructions displayed in the following sub-sections.
 ## Submit the simulation job
 
 The simulation job was submitted to SLURM scheduling system on Pegasus (HPC cluster at GWU), requesting 2 nodes of the `small-gpu` partition; CLI: `sbatch pegasus.slurm`.
+(Note: The SLURM submission script was designed for the user `mesnardo` to run on Pegasus; do not use it as such; use it as an example to develop your own submission script.)
 
 Hardware configuration of small GPU nodes:
 


### PR DESCRIPTION
PR with all changes for the revision of the ReScience manuscript.

Includes:

* c03805b Add DOI of Zenodo deposit with the Docker and Singularity images
* 41eaabc Add script to plot the nominal mesh grid and add the png figure of it
* 60eb292 Add link to hardware configuration and runtimes (to README)
* 2727b85 Add warning about memory requirement to run the Docker container for generating secondary data and figures
  * and basic instructions to launch an AWS EC2 instance (`t3.2xlarge` with 32 GB of memory) and run the container on it
* a06bec9 Add host requirements to README
* 061f755 Add instructions to launch and configure EC2 instance to run the base case simulation 